### PR TITLE
FLO-11651. Downgrade infinite scroll library for performance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
         "isteven-multi-select.css"
     ],
     "dependencies": {
-        "ngInfiniteScroll": "1.2.2"
+        "ngInfiniteScroll": "1.2.0"
     },
     "ignore"    : [
         ".git",


### PR DESCRIPTION
Downgrading ng-infinite-scroll to 1.2.0 to avoid infinite digest loops which kills performance. See https://github.com/sroze/ngInfiniteScroll/issues/235
